### PR TITLE
fix: remove needless pointers for increase performance

### DIFF
--- a/bidirectional_ch_n_to_n.go
+++ b/bidirectional_ch_n_to_n.go
@@ -121,7 +121,7 @@ func (graph *Graph) directionalSearchManyToMany(
 		graph.Reporter.VertexSettled(int(d), endpointIndex, vertex.id, q.Len())
 	}
 	// Edge relaxation in a forward propagation
-	var vertexList []*incidentEdge
+	var vertexList []incidentEdge
 	if d == forward {
 		vertexList = graph.Vertices[vertex.id].outIncidentEdges
 	} else {

--- a/contraction.go
+++ b/contraction.go
@@ -39,8 +39,7 @@ func (graph *Graph) Preprocess(pqImportance *importanceHeap) {
 //
 // inEdges Incoming edges from vertex
 // outEdges Outcoming edges from vertex
-//
-func (graph *Graph) markNeighbors(inEdges, outEdges []*incidentEdge) {
+func (graph *Graph) markNeighbors(inEdges, outEdges []incidentEdge) {
 	for i := range inEdges {
 		temp := inEdges[i]
 		graph.Vertices[temp.vertexID].delNeighbors++
@@ -54,7 +53,6 @@ func (graph *Graph) markNeighbors(inEdges, outEdges []*incidentEdge) {
 // contractNode
 //
 // vertex Vertex to be contracted
-//
 func (graph *Graph) contractNode(vertex *Vertex) {
 	// Consider all vertices with edges incoming TO current vertex as U
 	incomingEdges := vertex.inIncidentEdges
@@ -97,7 +95,6 @@ func (graph *Graph) contractNode(vertex *Vertex) {
 //
 // vertex - Vertex for making possible shortcuts around
 // pmax - path cost restriction
-//
 func (graph *Graph) processIncidentEdges(vertex *Vertex, pmax float64) {
 	incomingEdges := vertex.inIncidentEdges
 	outcomingEdges := vertex.outIncidentEdges
@@ -107,8 +104,7 @@ func (graph *Graph) processIncidentEdges(vertex *Vertex, pmax float64) {
 	batchShortcuts := make([]*ShortcutPath, 0, len(incomingEdges)*len(outcomingEdges))
 
 	previousOrderPos := int64(vertex.orderPos - 1)
-	for i := range incomingEdges {
-		u := incomingEdges[i]
+	for _, u := range incomingEdges {
 		inVertex := u.vertexID
 		// Do not consider any vertex has been excluded earlier
 		if graph.Vertices[inVertex].contracted {
@@ -116,8 +112,7 @@ func (graph *Graph) processIncidentEdges(vertex *Vertex, pmax float64) {
 		}
 		inCost := u.weight
 		graph.shortestPathsWithMaxCost(inVertex, pmax, previousOrderPos) // Finds the shortest distances from the inVertex to all outVertices.
-		for j := range outcomingEdges {
-			w := outcomingEdges[j]
+		for _, w := range outcomingEdges {
 			outVertex := w.vertexID
 			outVertexPtr := graph.Vertices[outVertex]
 			// Do not consider any vertex has been excluded earlier
@@ -154,7 +149,6 @@ func (graph *Graph) insertShortcuts(shortcuts []*ShortcutPath) {
 // fromVertex - Library defined ID of target vertex where shortcut leads to
 // viaVertex - Library defined ID of vertex through which the shortcut exists
 // summaryCost - Travel path of a shortcut
-//
 func (graph *Graph) createOrUpdateShortcut(fromVertex, toVertex, viaVertex int64, summaryCost float64) {
 	if _, ok := graph.shortcuts[fromVertex]; !ok {
 		// If there is no such shortcut then add one.

--- a/contraction.go
+++ b/contraction.go
@@ -101,7 +101,8 @@ func (graph *Graph) processIncidentEdges(vertex *Vertex, pmax float64) {
 	if len(outcomingEdges) == 0 {
 		return
 	}
-	batchShortcuts := make([]*ShortcutPath, 0, len(incomingEdges)*len(outcomingEdges))
+
+	batchShortcuts := make([]ShortcutPath, 0)
 
 	previousOrderPos := int64(vertex.orderPos - 1)
 	for _, u := range incomingEdges {
@@ -128,17 +129,18 @@ func (graph *Graph) processIncidentEdges(vertex *Vertex, pmax float64) {
 				outVertexPtr.distance.previousSourceID != inVertex { // Optional condition: if previous shortestPathsWithMaxCost(...) call has changed shortest path tree
 
 				// Collect needed shortcuts
-				batchShortcuts = append(batchShortcuts, &ShortcutPath{From: inVertex, To: outVertex, Via: vertex.vertexNum, Cost: neighborsWeights})
+				batchShortcuts = append(batchShortcuts, ShortcutPath{From: inVertex, To: outVertex, Via: vertex.vertexNum, Cost: neighborsWeights})
 			}
 		}
 	}
+
 	graph.insertShortcuts(batchShortcuts)
 }
 
 // insertShortcuts Creates (or updates: it depends on conditions) multiple shortcuts in graph structure
-func (graph *Graph) insertShortcuts(shortcuts []*ShortcutPath) {
-	for i := range shortcuts {
-		d := shortcuts[i]
+func (graph *Graph) insertShortcuts(batchShortcuts []ShortcutPath) {
+	for i := range batchShortcuts {
+		d := batchShortcuts[i]
 		graph.createOrUpdateShortcut(d.From, d.To, d.Via, d.Cost)
 	}
 }

--- a/dijkstra_bidirectional.go
+++ b/dijkstra_bidirectional.go
@@ -95,7 +95,7 @@ func (graph *Graph) directionalSearch(d direction, q *vertexDistHeap, localProce
 	if vertex.dist <= *estimate {
 		localProcessed[vertex.id] = true
 		// Edge relaxation in a forward propagation
-		var vertexList []*incidentEdge
+		var vertexList []incidentEdge
 		if d == forward {
 			vertexList = graph.Vertices[vertex.id].outIncidentEdges
 		} else {

--- a/dijkstra_local.go
+++ b/dijkstra_local.go
@@ -9,7 +9,7 @@ const (
 func (graph *Graph) shortestPathsWithMaxCost(source int64, maxcost float64, previousOrderPos int64) {
 	// Heap to store traveled distance
 	pqComparator := &distanceHeap{}
-	pqComparator.Push(graph.Vertices[source])
+	pqComparator.Push(&graph.Vertices[source])
 
 	// Instead of inializing distances to Infinity every single shortestPathsWithMaxCost(...) call we can do following
 	// Set dist[source] -> 0 (as usual)
@@ -34,7 +34,7 @@ func (graph *Graph) shortestPathsWithMaxCost(source int64, maxcost float64, prev
 		for i := range vertexList {
 			temp := vertexList[i].vertexID
 			cost := vertexList[i].weight
-			tempPtr := graph.Vertices[temp]
+			tempPtr := &graph.Vertices[temp]
 			// Do not consider any vertex has been excluded earlier
 			if tempPtr.contracted {
 				continue

--- a/graph.go
+++ b/graph.go
@@ -16,7 +16,7 @@ type Graph struct {
 	restrictions map[int64]map[int64]int64
 	mapping      map[int64]int64
 
-	Vertices     []*Vertex
+	Vertices     []Vertex
 	edgesNum     int64
 	shortcutsNum int64
 
@@ -36,7 +36,7 @@ type Reporter interface {
 func NewGraph() *Graph {
 	return &Graph{
 		mapping:      make(map[int64]int64),
-		Vertices:     make([]*Vertex, 0),
+		Vertices:     make([]Vertex, 0),
 		edgesNum:     0,
 		shortcutsNum: 0,
 		shortcuts:    make(map[int64]map[int64]*ShortcutPath),
@@ -53,7 +53,7 @@ func (graph *Graph) CreateVertex(label int64) error {
 	if graph.frozen {
 		return ErrGraphIsFrozen
 	}
-	v := &Vertex{
+	v := Vertex{
 		Label:        label,
 		delNeighbors: 0,
 		distance:     NewDistance(),
@@ -146,7 +146,7 @@ func (graph *Graph) computeImportance() *importanceHeap {
 	heap.Init(pqImportance)
 	for i := range graph.Vertices {
 		graph.Vertices[i].computeImportance()
-		heap.Push(pqImportance, graph.Vertices[i])
+		heap.Push(pqImportance, &graph.Vertices[i])
 	}
 	graph.Freeze()
 	return pqImportance

--- a/graph.go
+++ b/graph.go
@@ -92,8 +92,8 @@ func (graph *Graph) AddEdge(from, to int64, weight float64) error {
 }
 
 func (graph *Graph) addEdge(from, to int64, weight float64) {
-	graph.Vertices[from].outIncidentEdges = append(graph.Vertices[from].outIncidentEdges, &incidentEdge{vertexID: to, weight: weight})
-	graph.Vertices[to].inIncidentEdges = append(graph.Vertices[to].inIncidentEdges, &incidentEdge{vertexID: from, weight: weight})
+	graph.Vertices[from].outIncidentEdges = append(graph.Vertices[from].outIncidentEdges, incidentEdge{vertexID: to, weight: weight})
+	graph.Vertices[to].inIncidentEdges = append(graph.Vertices[to].inIncidentEdges, incidentEdge{vertexID: from, weight: weight})
 }
 
 // AddShortcut Adds new shortcut between two vertices

--- a/incident_edge.go
+++ b/incident_edge.go
@@ -11,7 +11,7 @@ type incidentEdge struct {
 // incomingVertexID - Library defined ID of vertex
 // weight - Travel cost of incoming edge
 func (vertex *Vertex) addInIncidentEdge(incomingVertexID int64, weight float64) {
-	vertex.inIncidentEdges = append(vertex.inIncidentEdges, &incidentEdge{incomingVertexID, weight})
+	vertex.inIncidentEdges = append(vertex.inIncidentEdges, incidentEdge{incomingVertexID, weight})
 }
 
 // addOutIncidentEdge Adds incident edge's to pool of "outcoming" edges of given vertex.
@@ -19,7 +19,7 @@ func (vertex *Vertex) addInIncidentEdge(incomingVertexID int64, weight float64) 
 // outcomingVertexID - Library defined ID of vertex
 // weight - Travel cost of outcoming edge
 func (vertex *Vertex) addOutIncidentEdge(outcomingVertexID int64, weight float64) {
-	vertex.outIncidentEdges = append(vertex.outIncidentEdges, &incidentEdge{outcomingVertexID, weight})
+	vertex.outIncidentEdges = append(vertex.outIncidentEdges, incidentEdge{outcomingVertexID, weight})
 }
 
 // findInIncidentEdge Returns index of incoming incident edge by vertex ID

--- a/vertex.go
+++ b/vertex.go
@@ -2,9 +2,9 @@ package ch
 
 // Vertex All information about vertex
 type Vertex struct {
-	distance         *Distance
-	inIncidentEdges  []*incidentEdge
-	outIncidentEdges []*incidentEdge
+	distance         Distance
+	inIncidentEdges  []incidentEdge
+	outIncidentEdges []incidentEdge
 
 	vertexNum int64
 	Label     int64
@@ -86,8 +86,8 @@ type Distance struct {
 }
 
 // NewDistance Constructor for Distance
-func NewDistance() *Distance {
-	return &Distance{
+func NewDistance() Distance {
+	return Distance{
 		previousOrderPos: -1,
 		previousSourceID: -1,
 		distance:         Infinity,
@@ -98,7 +98,6 @@ func NewDistance() *Distance {
 //
 // labelExternal - User defined ID of vertex
 // If vertex is not found then returns (-1; false)
-//
 func (graph *Graph) FindVertex(labelExternal int64) (idx int64, ok bool) {
 	idx, ok = graph.mapping[labelExternal]
 	if !ok {

--- a/vertex.go
+++ b/vertex.go
@@ -62,13 +62,13 @@ func (vertex *Vertex) computeImportance() {
 
 // bidirectedEdges Number of bidirected edges
 func (vertex *Vertex) bidirectedEdges() int {
-	hash := make(map[int64]bool)
+	hash := make(map[int64]struct{}, len(vertex.inIncidentEdges))
 	for _, e := range vertex.inIncidentEdges {
-		hash[e.vertexID] = true
+		hash[e.vertexID] = struct{}{}
 	}
 	ans := 0
-	for _, e := range vertex.outIncidentEdges {
-		if hash[e.vertexID] {
+	for i := range vertex.outIncidentEdges {
+		if _, ok := hash[vertex.outIncidentEdges[i].vertexID]; ok {
 			ans++
 		}
 	}


### PR DESCRIPTION
https://medium.com/@philpearl/bad-go-slices-of-pointers-ed3c06b8bb41
Using pointers with slices in Golang often causes bad errors since the slices are pointers by default. When iterating them, it bloats L caches and prevents them from caching the page of slice which will increase iteration and lookup performance .
Notable results : 

- Creating CH projection is now 78% faster and using 22% less allocations. (very critical improvement)
- Static case ShortestPath queries are now 29% faster with the same memory usage.
- CH ShortestPath queries are now 22% faster with the same memory usage.
- CH OneToMany queries are now 26% faster with same memory usage.
- CH ManyToMany queries are now 17% faster with the same memory usage.

Benchmarks with previous and current version is :
```Old 
BenchmarkPrepareContracts-12    	       1	8209383487 ns/op	362367688 B/op	 3744861 allocs/op
New
BenchmarkPrepareContracts-12                  1	4612412134 ns/op	367939104 B/op	 2956250 allocs/op
Difference
Preparing contracts is 78% faster with 22% less allocations

BenchmarkStaticCaseShortestPath/CH_shortest_path/vertices-187853-edges-366113-shortcuts-394840-12         	    1093           1106627 ns/op	  3455516 B/op	    1031 allocs/op
BenchmarkStaticCaseShortestPath/CH_shortest_path/vertices-187853-edges-366113-shortcuts-394840-12         	     828	   1425856 ns/op	 3455536 B/op	    1031 allocs/op

Difference 
29% faster with the same memory usage

Old
BenchmarkShortestPath/CH_shortest_path/4/vertices-4-edges-9-shortcuts-1-12         	 1333530	      1019 ns/op	     551 B/op	      17 allocs/op
BenchmarkShortestPath/CH_shortest_path/8/vertices-8-edges-61-shortcuts-1-12        	  479952	      2173 ns/op	     916 B/op	      27 allocs/op
BenchmarkShortestPath/CH_shortest_path/16/vertices-16-edges-316-shortcuts-31-12    	  177348	      6186 ns/op	    2118 B/op	      51 allocs/op
BenchmarkShortestPath/CH_shortest_path/32/vertices-32-edges-1404-shortcuts-123-12  	   68054	     17027 ns/op	    4757 B/op	      90 allocs/op
BenchmarkShortestPath/CH_shortest_path/64/vertices-64-edges-5894-shortcuts-322-12  	   31818	     41262 ns/op	   10522 B/op	     172 allocs/op
BenchmarkShortestPath/CH_shortest_path/128/vertices-128-edges-23977-shortcuts-1315-12   10000	    134254 ns/op	   23038 B/op	     350 allocs/op
BenchmarkShortestPath/CH_shortest_path/256/vertices-256-edges-97227-shortcuts-5276-12    3325	    306463 ns/op	   49007 B/op	     727 allocs/op
New
BenchmarkShortestPath/CH_shortest_path/4/vertices-4-edges-9-shortcuts-1-12         	 1329616	      	   1179 ns/op	      551 B/op	      17 allocs/op
BenchmarkShortestPath/CH_shortest_path/8/vertices-8-edges-61-shortcuts-1-12        	  609163	      	   1870 ns/op	      917 B/op	      27 allocs/op
BenchmarkShortestPath/CH_shortest_path/16/vertices-16-edges-316-shortcuts-31-12    	  204030	      	   5959 ns/op	     2119 B/op	      51 allocs/op
BenchmarkShortestPath/CH_shortest_path/32/vertices-32-edges-1404-shortcuts-123-12  	   75933	     	  14815 ns/op	     4754 B/op	      90 allocs/op
BenchmarkShortestPath/CH_shortest_path/64/vertices-64-edges-5894-shortcuts-322-12  	   34176	     	  35290 ns/op	    10523 B/op	     172 allocs/op
BenchmarkShortestPath/CH_shortest_path/128/vertices-128-edges-23977-shortcuts-1315-12   12301	    	 105521 ns/op	    23196 B/op	     352 allocs/op
BenchmarkShortestPath/CH_shortest_path/256/vertices-256-edges-97227-shortcuts-5276-12    4063	    	 249454 ns/op      48826 B/op	     724 allocs/op

Difference 
ShortestPath is overall get 22% faster with almost 1% less memory usage

New
BenchmarkShortestPathOneToMany/CH_shortest_path/4/vertices-4-edges-9-shortcuts-1-12         	  305936	      3809 ns/op	    1905 B/op	      68 allocs/op
BenchmarkShortestPathOneToMany/CH_shortest_path/8/vertices-8-edges-61-shortcuts-1-12        	  137943	      9193 ns/op	    3267 B/op	     117 allocs/op
BenchmarkShortestPathOneToMany/CH_shortest_path/16/vertices-16-edges-316-shortcuts-31-12    	   45684	     29144 ns/op	    7725 B/op	     232 allocs/op
BenchmarkShortestPathOneToMany/CH_shortest_path/32/vertices-32-edges-1404-shortcuts-123-12  	   16304	     63243 ns/op	   15875 B/op	     407 allocs/op
BenchmarkShortestPathOneToMany/CH_shortest_path/64/vertices-64-edges-5894-shortcuts-322-12  	    7719	    154857 ns/op	   33850 B/op	     792 allocs/op
BenchmarkShortestPathOneToMany/CH_shortest_path/128/vertices-128-edges-23977-shortcuts-1315-12         	    2811	    437840 ns/op	   74195 B/op	    1643 allocs/op
BenchmarkShortestPathOneToMany/CH_shortest_path/256/vertices-256-edges-97227-shortcuts-5276-12         	     994	   1227365 ns/op	  159962 B/op	    3492 allocs/op
BenchmarkOldWayShortestPathOneToMany/CH_shortest_path/4/vertices-4-edges-9-shortcuts-1-12              	  280868	      5224 ns/op	    2756 B/op	      85 allocs/op
BenchmarkOldWayShortestPathOneToMany/CH_shortest_path/8/vertices-8-edges-61-shortcuts-1-12             	  126960	      9323 ns/op	    4583 B/op	     137 allocs/op
BenchmarkOldWayShortestPathOneToMany/CH_shortest_path/16/vertices-16-edges-316-shortcuts-31-12         	   40964	     28326 ns/op	   10590 B/op	     258 allocs/op
BenchmarkOldWayShortestPathOneToMany/CH_shortest_path/32/vertices-32-edges-1404-shortcuts-123-12       	   15608	     72862 ns/op	   23763 B/op	     451 allocs/op
BenchmarkOldWayShortestPathOneToMany/CH_shortest_path/64/vertices-64-edges-5894-shortcuts-322-12       	    6974	    176117 ns/op	   52586 B/op	     864 allocs/op
BenchmarkOldWayShortestPathOneToMany/CH_shortest_path/128/vertices-128-edges-23977-shortcuts-1315-12   	    2630	    499794 ns/op	  114949 B/op	    1748 allocs/op
BenchmarkOldWayShortestPathOneToMany/CH_shortest_path/256/vertices-256-edges-97227-shortcuts-5276-12   	     945	   1288564 ns/op	  247045 B/op	    3670 allocs/op
BenchmarkTargetNodesShortestPathOneToMany/CH_shortest_path/2/vertices-187853-edges-366113-shortcuts-394840-targets-1-12         	     444	   2424764 ns/op	 6153047 B/op	    2498 allocs/op
BenchmarkTargetNodesShortestPathOneToMany/CH_shortest_path/4/vertices-187853-edges-366113-shortcuts-394840-targets-4-12         	     247	   4734516 ns/op	 6289175 B/op	    6806 allocs/op
BenchmarkTargetNodesShortestPathOneToMany/CH_shortest_path/8/vertices-187853-edges-366113-shortcuts-394840-targets-2-12         	     603	   1965843 ns/op	 6137265 B/op	    2326 allocs/op
BenchmarkTargetNodesShortestPathOneToMany/CH_shortest_path/16/vertices-187853-edges-366113-shortcuts-394840-targets-11-12       	     100	  10892781 ns/op	 6610253 B/op	   15394 allocs/op
BenchmarkTargetNodesShortestPathOneToMany/CH_shortest_path/32/vertices-187853-edges-366113-shortcuts-394840-targets-1-12        	     853	   1646152 ns/op	 6109997 B/op	    1390 allocs/op
BenchmarkTargetNodesShortestPathOneToMany/CH_shortest_path/64/vertices-187853-edges-366113-shortcuts-394840-targets-34-12       	      36	  31601942 ns/op	 7913826 B/op	   53472 allocs/op
BenchmarkTargetNodesShortestPathOneToMany/CH_shortest_path/128/vertices-187853-edges-366113-shortcuts-394840-targets-63-12      	      20	  63749003 ns/op	 9396353 B/op	   98130 allocs/op
BenchmarkTargetNodesOldWayShortestPathOneToMany/CH_shortest_path/2/vertices-187853-edges-366113-shortcuts-394840-targets-1-12   	     622	   1890782 ns/op	 3515536 B/op	    2500 allocs/op
BenchmarkTargetNodesOldWayShortestPathOneToMany/CH_shortest_path/4/vertices-187853-edges-366113-shortcuts-394840-targets-4-12   	     189	   6207512 ns/op	13891751 B/op	    6948 allocs/op
BenchmarkTargetNodesOldWayShortestPathOneToMany/CH_shortest_path/8/vertices-187853-edges-366113-shortcuts-394840-targets-2-12   	     464	   2392462 ns/op	 6907903 B/op	    2372 allocs/op
BenchmarkTargetNodesOldWayShortestPathOneToMany/CH_shortest_path/16/vertices-187853-edges-366113-shortcuts-394840-targets-11-12 	      93	  15498683 ns/op	38120614 B/op	   15880 allocs/op
BenchmarkTargetNodesOldWayShortestPathOneToMany/CH_shortest_path/32/vertices-187853-edges-366113-shortcuts-394840-targets-1-12  	     915	   1202467 ns/op	 3472518 B/op	    1392 allocs/op
BenchmarkTargetNodesOldWayShortestPathOneToMany/CH_shortest_path/64/vertices-187853-edges-366113-shortcuts-394840-targets-34-12 	      22	  51530000 ns/op	118138130 B/op	   55302 allocs/op
BenchmarkTargetNodesOldWayShortestPathOneToMany/CH_shortest_path/128/vertices-187853-edges-366113-shortcuts-394840-targets-63-12         	      12	  97098488 ns/op	218823310 B/op	  101509 allocs/op
BenchmarkStaticCaseShortestPathOneToMany/CH_shortest_path_(one_to_many)/vertices-187853-edges-366113-shortcuts-394840-12                 	     196	   6030186 ns/op	 6386644 B/op	    9076 allocs/op
BenchmarkStaticCaseOldWayShortestPathOneToMany/CH_shortest_path_(one_to_many)/vertices-187853-edges-366113-shortcuts-394840-12           	     122	  10358125 ns/op	17434396 B/op	    9290 allocs/op
Old
BenchmarkShortestPathOneToMany/CH_shortest_path/4/vertices-4-edges-9-shortcuts-1-12         	  307701	      3962 ns/op	    1906 B/op	      68 allocs/op
BenchmarkShortestPathOneToMany/CH_shortest_path/8/vertices-8-edges-61-shortcuts-1-12        	  142958	      8717 ns/op	    3266 B/op	     117 allocs/op
BenchmarkShortestPathOneToMany/CH_shortest_path/16/vertices-16-edges-316-shortcuts-31-12    	   46142	     27169 ns/op	    7723 B/op	     232 allocs/op
BenchmarkShortestPathOneToMany/CH_shortest_path/32/vertices-32-edges-1404-shortcuts-123-12  	   18664	     64182 ns/op	   15875 B/op	     407 allocs/op
BenchmarkShortestPathOneToMany/CH_shortest_path/64/vertices-64-edges-5894-shortcuts-322-12  	    7048	    166548 ns/op	   33894 B/op	     793 allocs/op
BenchmarkShortestPathOneToMany/CH_shortest_path/128/vertices-128-edges-23977-shortcuts-1315-12         	    2374	    510723 ns/op	   74000 B/op	    1638 allocs/op
BenchmarkShortestPathOneToMany/CH_shortest_path/256/vertices-256-edges-97227-shortcuts-5276-12         	     802	   1523527 ns/op	  160464 B/op	    3498 allocs/op
BenchmarkOldWayShortestPathOneToMany/CH_shortest_path/4/vertices-4-edges-9-shortcuts-1-12              	  283292	      5844 ns/op	    2756 B/op	      85 allocs/op
BenchmarkOldWayShortestPathOneToMany/CH_shortest_path/8/vertices-8-edges-61-shortcuts-1-12             	  136572	      9859 ns/op	    4582 B/op	     137 allocs/op
BenchmarkOldWayShortestPathOneToMany/CH_shortest_path/16/vertices-16-edges-316-shortcuts-31-12         	   39621	     31623 ns/op	   10591 B/op	     258 allocs/op
BenchmarkOldWayShortestPathOneToMany/CH_shortest_path/32/vertices-32-edges-1404-shortcuts-123-12       	   14776	     78857 ns/op	   23756 B/op	     451 allocs/op
BenchmarkOldWayShortestPathOneToMany/CH_shortest_path/64/vertices-64-edges-5894-shortcuts-322-12       	    6345	    207403 ns/op	   52691 B/op	     866 allocs/op
BenchmarkOldWayShortestPathOneToMany/CH_shortest_path/128/vertices-128-edges-23977-shortcuts-1315-12   	    2256	    617323 ns/op	  114794 B/op	    1747 allocs/op
BenchmarkOldWayShortestPathOneToMany/CH_shortest_path/256/vertices-256-edges-97227-shortcuts-5276-12   	     804	   1526640 ns/op	  247127 B/op	    3665 allocs/op
BenchmarkTargetNodesShortestPathOneToMany/CH_shortest_path/2/vertices-187853-edges-366113-shortcuts-394840-targets-1-12         	     385	   2765643 ns/op	 6153009 B/op	    2498 allocs/op
BenchmarkTargetNodesShortestPathOneToMany/CH_shortest_path/4/vertices-187853-edges-366113-shortcuts-394840-targets-4-12         	     213	   5472667 ns/op	 6289157 B/op	    6806 allocs/op
BenchmarkTargetNodesShortestPathOneToMany/CH_shortest_path/8/vertices-187853-edges-366113-shortcuts-394840-targets-2-12         	     457	   2522450 ns/op	 6137262 B/op	    2326 allocs/op
BenchmarkTargetNodesShortestPathOneToMany/CH_shortest_path/16/vertices-187853-edges-366113-shortcuts-394840-targets-11-12       	     100	  11375174 ns/op	 6610296 B/op	   15395 allocs/op
BenchmarkTargetNodesShortestPathOneToMany/CH_shortest_path/32/vertices-187853-edges-366113-shortcuts-394840-targets-1-12        	     585	   1720919 ns/op	 6109997 B/op	    1390 allocs/op
BenchmarkTargetNodesShortestPathOneToMany/CH_shortest_path/64/vertices-187853-edges-366113-shortcuts-394840-targets-34-12       	      31	  37212734 ns/op	 7913857 B/op	   53473 allocs/op
BenchmarkTargetNodesShortestPathOneToMany/CH_shortest_path/128/vertices-187853-edges-366113-shortcuts-394840-targets-63-12      	      18	  69131083 ns/op	 9396345 B/op	   98129 allocs/op
BenchmarkTargetNodesOldWayShortestPathOneToMany/CH_shortest_path/2/vertices-187853-edges-366113-shortcuts-394840-targets-1-12   	     427	   2875896 ns/op	 3515538 B/op	    2500 allocs/op
BenchmarkTargetNodesOldWayShortestPathOneToMany/CH_shortest_path/4/vertices-187853-edges-366113-shortcuts-394840-targets-4-12   	     140	   8640290 ns/op	13891857 B/op	    6950 allocs/op
BenchmarkTargetNodesOldWayShortestPathOneToMany/CH_shortest_path/8/vertices-187853-edges-366113-shortcuts-394840-targets-2-12   	     373	   3150679 ns/op	 6907878 B/op	    2372 allocs/op
BenchmarkTargetNodesOldWayShortestPathOneToMany/CH_shortest_path/16/vertices-187853-edges-366113-shortcuts-394840-targets-11-12 	      74	  21175596 ns/op	38120813 B/op	   15883 allocs/op
BenchmarkTargetNodesOldWayShortestPathOneToMany/CH_shortest_path/32/vertices-187853-edges-366113-shortcuts-394840-targets-1-12  	     726	   1584533 ns/op	 3472503 B/op	    1391 allocs/op
BenchmarkTargetNodesOldWayShortestPathOneToMany/CH_shortest_path/64/vertices-187853-edges-366113-shortcuts-394840-targets-34-12 	      16	  73828801 ns/op	118137395 B/op	   55301 allocs/op
BenchmarkTargetNodesOldWayShortestPathOneToMany/CH_shortest_path/128/vertices-187853-edges-366113-shortcuts-394840-targets-63-12         	       8	 130782596 ns/op	218822732 B/op	  101504 allocs/op
BenchmarkStaticCaseShortestPathOneToMany/CH_shortest_path_(one_to_many)/vertices-187853-edges-366113-shortcuts-394840-12                 	     147	   7795818 ns/op	 6386591 B/op	    9076 allocs/op
BenchmarkStaticCaseOldWayShortestPathOneToMany/CH_shortest_path_(one_to_many)/vertices-187853-edges-366113-shortcuts-394840-12           	     100	  10732341 ns/op	17434331 B/op	    9289 allocs/op

Difference
OneToMany is 26% faster with same memory usage

Old
BenchmarkShortestPathManyToMany/CH_shortest_path/4/vertices-4-edges-9-shortcuts-1-12         	          193771	      6904 ns/op	    4771 B/op	      99 allocs/op
BenchmarkShortestPathManyToMany/CH_shortest_path/8/vertices-8-edges-61-shortcuts-1-12        	           94941	     14165 ns/op	    5634 B/op	     132 allocs/op
BenchmarkShortestPathManyToMany/CH_shortest_path/16/vertices-16-edges-316-shortcuts-31-12    	           18716	     61497 ns/op	   11713 B/op	     223 allocs/op
BenchmarkShortestPathManyToMany/CH_shortest_path/32/vertices-32-edges-1404-shortcuts-123-12  	            5253	    238033 ns/op	   25674 B/op	     399 allocs/op
BenchmarkShortestPathManyToMany/CH_shortest_path/64/vertices-64-edges-5894-shortcuts-322-12  	            1293	    950143 ns/op	   55178 B/op	     765 allocs/op
BenchmarkShortestPathManyToMany/CH_shortest_path/128/vertices-128-edges-23977-shortcuts-1315-12         	     301	   4260807 ns/op	  118019 B/op	    1518 allocs/op
BenchmarkShortestPathManyToMany/CH_shortest_path/256/vertices-256-edges-97227-shortcuts-5276-12         	      86	  19509133 ns/op	  252295 B/op	    3126 allocs/op
BenchmarkOldWayShortestPathManyToMany/CH_shortest_path/4/vertices-4-edges-9-shortcuts-1-12              	  282445	      4468 ns/op	    2756 B/op	      85 allocs/op
BenchmarkOldWayShortestPathManyToMany/CH_shortest_path/8/vertices-8-edges-61-shortcuts-1-12             	  129445	      9999 ns/op	    4583 B/op	     137 allocs/op
BenchmarkOldWayShortestPathManyToMany/CH_shortest_path/16/vertices-16-edges-316-shortcuts-31-12         	   42440	     29555 ns/op	   10592 B/op	     258 allocs/op
BenchmarkOldWayShortestPathManyToMany/CH_shortest_path/32/vertices-32-edges-1404-shortcuts-123-12       	   16510	     79495 ns/op	   23752 B/op	     451 allocs/op
BenchmarkOldWayShortestPathManyToMany/CH_shortest_path/64/vertices-64-edges-5894-shortcuts-322-12       	    6346	    201662 ns/op	   52696 B/op	     866 allocs/op
BenchmarkOldWayShortestPathManyToMany/CH_shortest_path/128/vertices-128-edges-23977-shortcuts-1315-12   	    2259	    574134 ns/op	  114796 B/op	    1747 allocs/op
BenchmarkOldWayShortestPathManyToMany/CH_shortest_path/256/vertices-256-edges-97227-shortcuts-5276-12   	     808	   1531215 ns/op	  247041 B/op	    3665 allocs/op
BenchmarkStaticCaseShortestPathManyToMany/CH_shortest_path_(many_to_many)/vertices-187853-12            	     123	   9134224 ns/op	  594232 B/op	    8553 allocs/op
BenchmarkStaticCaseOldWayShortestPathManyToMany/CH_shortest_path_(many_to_many)/vertices-187853-12      	     100	  10852451 ns/op	17434217 B/op	    9287 allocs/op
New
BenchmarkShortestPathManyToMany/CH_shortest_path/4/vertices-4-edges-9-shortcuts-1-12         	         198465	      7053 ns/op	    4771 B/op	      99 allocs/op
BenchmarkShortestPathManyToMany/CH_shortest_path/8/vertices-8-edges-61-shortcuts-1-12        	          93276	     12834 ns/op	    5634 B/op	     132 allocs/op
BenchmarkShortestPathManyToMany/CH_shortest_path/16/vertices-16-edges-316-shortcuts-31-12    	          19279	     59262 ns/op	   11714 B/op	     223 allocs/op
BenchmarkShortestPathManyToMany/CH_shortest_path/32/vertices-32-edges-1404-shortcuts-123-12  	           5402	    227077 ns/op	   25684 B/op	     399 allocs/op
BenchmarkShortestPathManyToMany/CH_shortest_path/64/vertices-64-edges-5894-shortcuts-322-12  	           1412	    877373 ns/op	   55120 B/op	     764 allocs/op
BenchmarkShortestPathManyToMany/CH_shortest_path/128/vertices-128-edges-23977-shortcuts-1315-12         	     332	   3761987 ns/op	  117902 B/op	    1517 allocs/op
BenchmarkShortestPathManyToMany/CH_shortest_path/256/vertices-256-edges-97227-shortcuts-5276-12         	      97	  16621356 ns/op	  249831 B/op	    3102 allocs/op
BenchmarkOldWayShortestPathManyToMany/CH_shortest_path/4/vertices-4-edges-9-shortcuts-1-12              	  281520	      4698 ns/op	    2756 B/op	      85 allocs/op
BenchmarkOldWayShortestPathManyToMany/CH_shortest_path/8/vertices-8-edges-61-shortcuts-1-12             	  127542	      9419 ns/op	    4580 B/op	     137 allocs/op
BenchmarkOldWayShortestPathManyToMany/CH_shortest_path/16/vertices-16-edges-316-shortcuts-31-12         	   36428	     32366 ns/op	   10589 B/op	     257 allocs/op
BenchmarkOldWayShortestPathManyToMany/CH_shortest_path/32/vertices-32-edges-1404-shortcuts-123-12       	   13867	     84872 ns/op	   23745 B/op	     451 allocs/op
BenchmarkOldWayShortestPathManyToMany/CH_shortest_path/64/vertices-64-edges-5894-shortcuts-322-12       	    5335	    195530 ns/op	   52577 B/op	     865 allocs/op
BenchmarkOldWayShortestPathManyToMany/CH_shortest_path/128/vertices-128-edges-23977-shortcuts-1315-12   	    1986	    511349 ns/op	  115138 B/op	    1750 allocs/op
BenchmarkOldWayShortestPathManyToMany/CH_shortest_path/256/vertices-256-edges-97227-shortcuts-5276-12   	     980	   1249070 ns/op	  246541 B/op	    3663 allocs/op
BenchmarkStaticCaseShortestPathManyToMany/CH_shortest_path_(many_to_many)/vertices-187853-12            	     171	   7241434 ns/op	  594516 B/op	    8557 allocs/op
BenchmarkStaticCaseOldWayShortestPathManyToMany/CH_shortest_path_(many_to_many)/vertices-187853-12      	     142	   9430202 ns/op	17434424 B/op	    9290 allocs/op

Difference
ManyToMany is now %17 faster with same memory usage
```