### PR TITLE
fix: Isochrones to return shortest distance

### DIFF
--- a/isochrones.go
+++ b/isochrones.go
@@ -7,10 +7,8 @@ import (
 
 // Isochrones Returns set of vertices and corresponding distances restricted by maximum travel cost for source vertex
 // source - source vertex (user defined label)
-// maxCost - restriction on travel cost for breadth search
+// maxCost - restriction on travel cost
 // See ref. https://wiki.openstreetmap.org/wiki/Isochrone and https://en.wikipedia.org/wiki/Isochrone_map
-// Note: implemented breadth-first searching path algorithm does not guarantee shortest pathes to reachable vertices (until all edges have cost 1.0). See ref: https://en.wikipedia.org/wiki/Breadth-first_search
-// Note: result for estimated costs could be also inconsistent due nature of data structure
 func (graph *Graph) Isochrones(source int64, maxCost float64) (map[int64]float64, error) {
 	var ok bool
 	if source, ok = graph.mapping[source]; !ok {

--- a/isochrones_test.go
+++ b/isochrones_test.go
@@ -10,9 +10,9 @@ func TestIsochrones(t *testing.T) {
 		3: 1.0,
 		4: 1.0,
 		6: 1.0,
-		7: 3.0,
+		7: 2.0,
 		1: 3.0,
-		8: 4.0, // <---- Because of breadth-first search
+		8: 4.0,
 		9: 2.0,
 	}
 	graph := Graph{}


### PR DESCRIPTION
This fix did not have the performance improvement that I hoped for (it's actually quite negligible). But for implementation correctness, still fixed it (as is evident from the test, it didn't return the shortest path).