### PR TITLE
Use heap.Push when contracting

### DIFF
--- a/contraction.go
+++ b/contraction.go
@@ -21,7 +21,7 @@ func (graph *Graph) Preprocess(pqImportance *importanceHeap) {
 		vertex := heap.Pop(pqImportance).(*Vertex)
 		vertex.computeImportance()
 		if pqImportance.Len() != 0 && vertex.importance > pqImportance.Peek().importance {
-			pqImportance.Push(vertex)
+			heap.Push(pqImportance, vertex)
 			continue
 		}
 		vertex.orderPos = extractionOrder


### PR DESCRIPTION
On the surface this looks like a bug using incorrect Push interface. Element pushed back should be moved to right place, but it is just appended to container.

From Lazy Updating section at https://jlazarsfeld.github.io/ch.150.project/sections/12-node-order/

> If its edge difference is no longer the min, then we update its cost and rebalance our PQ

However this *might* be optimization instead. In the next loop the heap.Pop() will swap() element to the front of the queue and then moves it with down() to right place.  Essentially this "Replacement" strategy: "Remove the root and put the new element in the root and sift down." (see [wikipedia](https://en.wikipedia.org/wiki/Heap_(data_structure)#Implementation)). As long we append element with priority higher than top (this is just validated) this should be fine,  but this relies on Go heap implementation.

Also this is probably faster if priority changes relatively little at the time. Then pushing "down" makes more sense. Vertex priority calculation and distribution both probably factor in.

Using heap.Push()  results different number of shortcuts:

    go test ./...

    2024/10/15 13:57:39 TestExport is Ok!
    --- FAIL: TestExport (3.79s)
        export_test.go:14: Please wait until contraction hierarchy is prepared
        export_test.go:16: TestExport is starting...
        export_test.go:21: Number of contractions should be 394840, but got 396764
    --- FAIL: TestImportedFileShortestPath (0.53s)
        import_test.go:13: TestImportedFileShortestPath is starting...
        import_test.go:21: Number of contractions should be 394840, but got 396764
        import_test.go:36: TestImportedFileShortestPath is Ok!
    FAIL
    FAIL    github.com/LdDl/ch      17.409s
    FAIL

Due that shortest-path performance also changes. Some are faster, some slower.

The heap.Push() is a bit slower when contracting these test cases, indicating that balancing the tree from front should be faster (see PR #21)

	$ benchstat old-bench.txt new-bench-push.txt

	goos: linux
	goarch: amd64
	pkg: github.com/LdDl/ch
	cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
	                                                                                                      │ old-bench.txt │          new-bench-push.txt          │
	                                                                                                      │    sec/op     │    sec/op     vs base                │
	ShortestPathManyToMany/CH_shortest_path/4/vertices-4-edges-9-4                                           5.323µ ± 15%   5.169µ ± 10%        ~ (p=0.853 n=10)
	ShortestPathManyToMany/CH_shortest_path/8/vertices-8-edges-61-4                                          9.454µ ±  4%   9.373µ ± 16%        ~ (p=0.853 n=10)
	ShortestPathManyToMany/CH_shortest_path/16/vertices-16-edges-316-4                                       46.65µ ±  9%   48.80µ ±  9%        ~ (p=0.190 n=10)
	ShortestPathManyToMany/CH_shortest_path/32/vertices-32-edges-1404-4                                      179.1µ ±  7%   182.9µ ± 10%        ~ (p=0.529 n=10)
	ShortestPathManyToMany/CH_shortest_path/64/vertices-64-edges-5894-4                                      697.2µ ±  9%   736.7µ ±  5%        ~ (p=0.052 n=10)
	ShortestPathManyToMany/CH_shortest_path/128/vertices-128-edges-23977-4                                   3.176m ±  8%   3.247m ±  4%        ~ (p=0.436 n=10)
	ShortestPathManyToMany/CH_shortest_path/256/vertices-256-edges-97227-4                                   14.25m ± 11%   14.61m ± 13%        ~ (p=0.393 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/4/vertices-4-edges-9-4                                     3.600µ ±  6%   3.530µ ±  7%        ~ (p=0.971 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/8/vertices-8-edges-61-4                                    6.816µ ± 15%   6.603µ ± 23%        ~ (p=0.247 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/16/vertices-16-edges-316-4                                 21.39µ ±  4%   22.59µ ±  8%        ~ (p=0.052 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/32/vertices-32-edges-1404-4                                54.42µ ± 11%   55.45µ ± 15%        ~ (p=0.315 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/64/vertices-64-edges-5894-4                                145.2µ ±  7%   142.9µ ±  4%        ~ (p=0.218 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/128/vertices-128-edges-23977-4                             432.9µ ±  9%   414.9µ ±  8%        ~ (p=0.353 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/256/vertices-256-edges-97227-4                             906.8µ ±  7%   920.7µ ± 12%        ~ (p=0.853 n=10)
	StaticCaseShortestPathManyToMany/CH_shortest_path_(many_to_many)/vertices-187853-4                       4.982m ±  8%   6.126m ± 15%  +22.96% (p=0.000 n=10)
	StaticCaseOldWayShortestPathManyToMany/CH_shortest_path_(many_to_many)/vertices-187853-4                 7.278m ± 15%   8.270m ± 15%  +13.63% (p=0.023 n=10)
	ShortestPathOneToMany/CH_shortest_path/4/vertices-4-edges-9-4                                            3.201µ ± 24%   3.156µ ± 31%        ~ (p=0.644 n=10)
	ShortestPathOneToMany/CH_shortest_path/8/vertices-8-edges-61-4                                           6.847µ ± 12%   6.916µ ± 13%        ~ (p=0.739 n=10)
	ShortestPathOneToMany/CH_shortest_path/16/vertices-16-edges-316-4                                        21.44µ ± 32%   21.06µ ± 42%        ~ (p=0.481 n=10)
	ShortestPathOneToMany/CH_shortest_path/32/vertices-32-edges-1404-4                                       60.92µ ± 72%   54.42µ ± 20%        ~ (p=0.143 n=10)
	ShortestPathOneToMany/CH_shortest_path/64/vertices-64-edges-5894-4                                       403.0µ ± 46%   132.4µ ± 21%  -67.14% (p=0.000 n=10)
	ShortestPathOneToMany/CH_shortest_path/128/vertices-128-edges-23977-4                                    432.1µ ± 45%   379.7µ ± 15%  -12.13% (p=0.029 n=10)
	ShortestPathOneToMany/CH_shortest_path/256/vertices-256-edges-97227-4                                   1059.7µ ± 11%   960.2µ ± 26%        ~ (p=0.165 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/4/vertices-4-edges-9-4                                      3.728µ ± 26%   3.615µ ±  6%        ~ (p=0.190 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/8/vertices-8-edges-61-4                                     6.928µ ± 18%   7.358µ ±  5%        ~ (p=0.075 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/16/vertices-16-edges-316-4                                  21.95µ ±  9%   22.41µ ±  8%        ~ (p=0.853 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/32/vertices-32-edges-1404-4                                 58.13µ ±  8%   56.11µ ±  8%        ~ (p=0.971 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/64/vertices-64-edges-5894-4                                 145.6µ ± 10%   143.9µ ±  7%        ~ (p=1.000 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/128/vertices-128-edges-23977-4                              416.7µ ±  6%   418.6µ ±  5%        ~ (p=0.315 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/256/vertices-256-edges-97227-4                              929.7µ ± 12%   920.4µ ± 12%        ~ (p=0.481 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/2/vertices-187853-edges-366113-targets-1-4             1.754m ±  7%   1.770m ± 20%        ~ (p=0.280 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/4/vertices-187853-edges-366113-targets-4-4             2.907m ± 19%   3.068m ± 13%        ~ (p=0.393 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/8/vertices-187853-edges-366113-targets-2-4             1.700m ±  9%   1.586m ±  9%        ~ (p=0.190 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/16/vertices-187853-edges-366113-targets-11-4           5.797m ±  7%   6.066m ± 13%        ~ (p=0.143 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/32/vertices-187853-edges-366113-targets-1-4            1.313m ± 19%   1.276m ± 16%        ~ (p=0.315 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/64/vertices-187853-edges-366113-targets-34-4           18.55m ± 15%   21.18m ±  7%  +14.20% (p=0.011 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/128/vertices-187853-edges-366113-targets-63-4          33.44m ±  9%   37.82m ±  9%  +13.10% (p=0.004 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/2/vertices-187853-edges-366113-targets-1-4       1.504m ± 16%   1.510m ± 11%        ~ (p=0.796 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/4/vertices-187853-edges-366113-targets-4-4       5.167m ±  9%   5.344m ± 19%        ~ (p=0.247 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/8/vertices-187853-edges-366113-targets-2-4       2.178m ± 12%   2.392m ± 14%        ~ (p=0.393 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/16/vertices-187853-edges-366113-targets-11-4     13.15m ± 13%   15.82m ± 28%  +20.34% (p=0.015 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/32/vertices-187853-edges-366113-targets-1-4      1.114m ±  7%   1.059m ± 20%        ~ (p=0.105 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/64/vertices-187853-edges-366113-targets-34-4     42.94m ± 19%   46.91m ± 20%        ~ (p=0.075 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/128/vertices-187853-edges-366113-targets-63-4    80.65m ± 13%   92.05m ± 23%  +14.13% (p=0.009 n=10)
	StaticCaseShortestPathOneToMany/CH_shortest_path_(one_to_many)/vertices-187853-edges-366113-4            3.436m ± 22%   4.634m ± 26%  +34.86% (p=0.000 n=10)
	StaticCaseOldWayShortestPathOneToMany/CH_shortest_path_(one_to_many)/vertices-187853-edges-366113-4      6.823m ±  9%   7.192m ±  9%   +5.41% (p=0.029 n=10)
	ShortestPath/CH_shortest_path/4/vertices-4-edges-9-4                                                     767.9n ± 21%   815.6n ±  7%        ~ (p=0.353 n=10)
	ShortestPath/CH_shortest_path/8/vertices-8-edges-61-4                                                    1.513µ ±  9%   1.527µ ±  6%        ~ (p=0.436 n=10)
	ShortestPath/CH_shortest_path/16/vertices-16-edges-316-4                                                 4.716µ ± 12%   4.859µ ±  7%        ~ (p=0.529 n=10)
	ShortestPath/CH_shortest_path/32/vertices-32-edges-1404-4                                                11.93µ ±  9%   11.92µ ±  3%        ~ (p=0.971 n=10)
	ShortestPath/CH_shortest_path/64/vertices-64-edges-5894-4                                                28.78µ ± 29%   30.10µ ± 10%        ~ (p=0.579 n=10)
	ShortestPath/CH_shortest_path/128/vertices-128-edges-23977-4                                             83.08µ ±  8%   93.07µ ±  8%  +12.02% (p=0.009 n=10)
	ShortestPath/CH_shortest_path/256/vertices-256-edges-97227-4                                             195.6µ ±  7%   194.2µ ±  6%        ~ (p=0.436 n=10)
	StaticCaseShortestPath/CH_shortest_path/vertices-187853-edges-366113-4                                   1.028m ± 10%   1.142m ±  7%  +11.05% (p=0.019 n=10)
	PrepareContracts-4                                                                                        2.683 ±  6%    2.995 ±  5%  +11.62% (p=0.000 n=10)
	geomean                                                                                                  319.3µ         322.4µ         +0.98%