### PR TITLE
Use heap.Fix() instead

### DIFF
--- a/contraction.go
+++ b/contraction.go
@@ -21,7 +21,7 @@ func (graph *Graph) Preprocess(pqImportance *importanceHeap) {
 		vertex := pqImportance.Peek()
 		oldimportance := vertex.importance
 		vertex.computeImportance()
-		if vertex.importance != oldimportance {
+		if vertex.importance > oldimportance {
 			heap.Fix(pqImportance, 0)
 			continue
 		}

--- a/contraction.go
+++ b/contraction.go
@@ -18,12 +18,14 @@ func (graph *Graph) Preprocess(pqImportance *importanceHeap) {
 		// update Importance of vertex "on demand" as follows:
 		// Before contracting vertex with currently smallest Importance, recompute its Importance and see if it is still the smallest
 		// If not pick next smallest one, recompute its Importance and see if that is the smallest now; If not, continue in same way ...
-		vertex := heap.Pop(pqImportance).(*Vertex)
+		vertex := pqImportance.Peek()
+		oldimportance := vertex.importance
 		vertex.computeImportance()
-		if pqImportance.Len() != 0 && vertex.importance > pqImportance.Peek().importance {
-			pqImportance.Push(vertex)
+		if vertex.importance != oldimportance {
+			heap.Fix(pqImportance, 0)
 			continue
 		}
+		vertex = heap.Pop(pqImportance).(*Vertex)
 		vertex.orderPos = extractionOrder
 		graph.contractNode(vertex)
 		if graph.verbose {

--- a/export_test.go
+++ b/export_test.go
@@ -14,7 +14,7 @@ func TestExport(t *testing.T) {
 	t.Log("Please wait until contraction hierarchy is prepared")
 	g.PrepareContractionHierarchies()
 	t.Log("TestExport is starting...")
-	correctNumShortcuts := int64(394840)
+	correctNumShortcuts := int64(395087)
 	correctNumVertices := 187853
 	evaluatedShortcuts := g.GetShortcutsNum()
 	if evaluatedShortcuts != correctNumShortcuts {

--- a/import_test.go
+++ b/import_test.go
@@ -14,7 +14,7 @@ func TestImportedFileShortestPath(t *testing.T) {
 	u := int64(69618)
 	v := int64(5924)
 
-	correctNumShortcuts := int64(394840)
+	correctNumShortcuts := int64(395087)
 	correctNumVertices := 187853
 	evaluatedShortcuts := g.GetShortcutsNum()
 	if evaluatedShortcuts != correctNumShortcuts {


### PR DESCRIPTION
The PR #20 used heap.Push() but contraction performance suffered. This PR uses heap.Fix() instead which will use either "down" or "up" strategy as needed. The benefit over original solution is little bit less obscure and at least documentation implies this is faster than heap.Pop() + heap.Push().

This will result different graph which was not what I expected initially. As noted in PR #20 I assumed that original code appends to array to implement "Replacement" strategy. I attempted with heap.Fix() the same strategy but there is a difference due heap.Pop() which would move last element first and then call down() on it. Hence it will result in different graph.

	$ go test ./...
	2024/10/15 17:50:27 TestExport is Ok!
	--- FAIL: TestExport (3.47s)
	    export_test.go:14: Please wait until contraction hierarchy is prepared
	    export_test.go:16: TestExport is starting...
	    export_test.go:21: Number of contractions should be 394840, but got 395087
	--- FAIL: TestImportedFileShortestPath (0.54s)
	    import_test.go:13: TestImportedFileShortestPath is starting...
	    import_test.go:21: Number of contractions should be 394840, but got 395087
	    import_test.go:36: TestImportedFileShortestPath is Ok!
	FAIL
	FAIL    github.com/LdDl/ch      17.013s
	FAIL

Many shortest distance tests get faster, contraction remains on par:

	$ benchstat old-bench.txt new-bench-heap-fix.txt
	goos: linux
	goarch: amd64
	pkg: github.com/LdDl/ch
	cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
	                                                                                                      │ old-bench.txt │        new-bench-heap-fix.txt        │
	                                                                                                      │    sec/op     │    sec/op     vs base                │
	ShortestPathManyToMany/CH_shortest_path/4/vertices-4-edges-9-4                                           5.323µ ± 15%   5.405µ ±  3%        ~ (p=0.796 n=10)
	ShortestPathManyToMany/CH_shortest_path/8/vertices-8-edges-61-4                                          9.454µ ±  4%   9.694µ ±  4%        ~ (p=0.143 n=10)
	ShortestPathManyToMany/CH_shortest_path/16/vertices-16-edges-316-4                                       46.65µ ±  9%   46.11µ ± 19%        ~ (p=1.000 n=10)
	ShortestPathManyToMany/CH_shortest_path/32/vertices-32-edges-1404-4                                      179.1µ ±  7%   179.6µ ± 16%        ~ (p=0.393 n=10)
	ShortestPathManyToMany/CH_shortest_path/64/vertices-64-edges-5894-4                                      697.2µ ±  9%   730.2µ ±  6%        ~ (p=0.143 n=10)
	ShortestPathManyToMany/CH_shortest_path/128/vertices-128-edges-23977-4                                   3.176m ±  8%   3.145m ±  9%        ~ (p=0.971 n=10)
	ShortestPathManyToMany/CH_shortest_path/256/vertices-256-edges-97227-4                                   14.25m ± 11%   14.57m ±  5%        ~ (p=0.529 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/4/vertices-4-edges-9-4                                     3.600µ ±  6%   3.569µ ± 14%        ~ (p=0.853 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/8/vertices-8-edges-61-4                                    6.816µ ± 15%   6.869µ ±  5%        ~ (p=0.781 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/16/vertices-16-edges-316-4                                 21.39µ ±  4%   22.24µ ±  8%        ~ (p=0.075 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/32/vertices-32-edges-1404-4                                54.42µ ± 11%   56.56µ ±  5%        ~ (p=0.218 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/64/vertices-64-edges-5894-4                                145.2µ ±  7%   143.4µ ± 20%        ~ (p=0.739 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/128/vertices-128-edges-23977-4                             432.9µ ±  9%   395.1µ ± 19%        ~ (p=0.165 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/256/vertices-256-edges-97227-4                             906.8µ ±  7%   921.6µ ± 10%        ~ (p=0.912 n=10)
	StaticCaseShortestPathManyToMany/CH_shortest_path_(many_to_many)/vertices-187853-4                       4.982m ±  8%   5.033m ±  9%        ~ (p=0.631 n=10)
	StaticCaseOldWayShortestPathManyToMany/CH_shortest_path_(many_to_many)/vertices-187853-4                 7.278m ± 15%   6.670m ± 16%        ~ (p=0.143 n=10)
	ShortestPathOneToMany/CH_shortest_path/4/vertices-4-edges-9-4                                            3.201µ ± 24%   3.207µ ±  4%        ~ (p=0.986 n=10)
	ShortestPathOneToMany/CH_shortest_path/8/vertices-8-edges-61-4                                           6.847µ ± 12%   6.390µ ± 10%   -6.68% (p=0.023 n=10)
	ShortestPathOneToMany/CH_shortest_path/16/vertices-16-edges-316-4                                        21.44µ ± 32%   20.48µ ±  5%   -4.46% (p=0.023 n=10)
	ShortestPathOneToMany/CH_shortest_path/32/vertices-32-edges-1404-4                                       60.92µ ± 72%   49.34µ ±  8%  -19.02% (p=0.002 n=10)
	ShortestPathOneToMany/CH_shortest_path/64/vertices-64-edges-5894-4                                       403.0µ ± 46%   123.5µ ± 18%  -69.35% (p=0.000 n=10)
	ShortestPathOneToMany/CH_shortest_path/128/vertices-128-edges-23977-4                                    432.1µ ± 45%   360.4µ ±  8%  -16.59% (p=0.000 n=10)
	ShortestPathOneToMany/CH_shortest_path/256/vertices-256-edges-97227-4                                   1059.7µ ± 11%   920.2µ ±  7%  -13.16% (p=0.000 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/4/vertices-4-edges-9-4                                      3.728µ ± 26%   3.636µ ±  3%        ~ (p=0.075 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/8/vertices-8-edges-61-4                                     6.928µ ± 18%   7.150µ ±  5%        ~ (p=0.280 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/16/vertices-16-edges-316-4                                  21.95µ ±  9%   22.17µ ± 12%        ~ (p=0.542 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/32/vertices-32-edges-1404-4                                 58.13µ ±  8%   55.62µ ± 10%        ~ (p=0.631 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/64/vertices-64-edges-5894-4                                 145.6µ ± 10%   147.5µ ±  6%        ~ (p=0.912 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/128/vertices-128-edges-23977-4                              416.7µ ±  6%   421.2µ ± 10%        ~ (p=0.436 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/256/vertices-256-edges-97227-4                              929.7µ ± 12%   951.7µ ±  7%        ~ (p=0.529 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/2/vertices-187853-edges-366113-targets-1-4             1.754m ±  7%   1.823m ± 10%        ~ (p=0.529 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/4/vertices-187853-edges-366113-targets-4-4             2.907m ± 19%   2.902m ±  6%        ~ (p=0.853 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/8/vertices-187853-edges-366113-targets-2-4             1.700m ±  9%   1.502m ± 16%  -11.67% (p=0.019 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/16/vertices-187853-edges-366113-targets-11-4           5.797m ±  7%   5.926m ± 12%        ~ (p=0.393 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/32/vertices-187853-edges-366113-targets-1-4            1.313m ± 19%   1.190m ± 14%        ~ (p=0.052 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/64/vertices-187853-edges-366113-targets-34-4           18.55m ± 15%   18.91m ± 17%        ~ (p=0.529 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/128/vertices-187853-edges-366113-targets-63-4          33.44m ±  9%   34.43m ± 11%        ~ (p=0.280 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/2/vertices-187853-edges-366113-targets-1-4       1.504m ± 16%   1.423m ± 27%        ~ (p=0.912 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/4/vertices-187853-edges-366113-targets-4-4       5.167m ±  9%   5.028m ± 11%        ~ (p=0.796 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/8/vertices-187853-edges-366113-targets-2-4       2.178m ± 12%   2.009m ± 20%        ~ (p=0.075 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/16/vertices-187853-edges-366113-targets-11-4     13.15m ± 13%   13.59m ± 10%        ~ (p=0.739 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/32/vertices-187853-edges-366113-targets-1-4      1.114m ±  7%   1.065m ± 18%        ~ (p=0.123 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/64/vertices-187853-edges-366113-targets-34-4     42.94m ± 19%   42.89m ± 17%        ~ (p=0.631 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/128/vertices-187853-edges-366113-targets-63-4    80.65m ± 13%   76.94m ± 16%        ~ (p=0.247 n=10)
	StaticCaseShortestPathOneToMany/CH_shortest_path_(one_to_many)/vertices-187853-edges-366113-4            3.436m ± 22%   3.844m ± 13%        ~ (p=0.075 n=10)
	StaticCaseOldWayShortestPathOneToMany/CH_shortest_path_(one_to_many)/vertices-187853-edges-366113-4      6.823m ±  9%   7.220m ± 14%        ~ (p=0.684 n=10)
	ShortestPath/CH_shortest_path/4/vertices-4-edges-9-4                                                     767.9n ± 21%   811.8n ± 21%        ~ (p=0.143 n=10)
	ShortestPath/CH_shortest_path/8/vertices-8-edges-61-4                                                    1.513µ ±  9%   1.517µ ±  9%        ~ (p=0.631 n=10)
	ShortestPath/CH_shortest_path/16/vertices-16-edges-316-4                                                 4.716µ ± 12%   4.692µ ±  7%        ~ (p=0.986 n=10)
	ShortestPath/CH_shortest_path/32/vertices-32-edges-1404-4                                                11.93µ ±  9%   11.14µ ± 19%        ~ (p=0.075 n=10)
	ShortestPath/CH_shortest_path/64/vertices-64-edges-5894-4                                                28.78µ ± 29%   29.51µ ±  6%        ~ (p=0.529 n=10)
	ShortestPath/CH_shortest_path/128/vertices-128-edges-23977-4                                             83.08µ ±  8%   86.34µ ± 11%        ~ (p=0.436 n=10)
	ShortestPath/CH_shortest_path/256/vertices-256-edges-97227-4                                             195.6µ ±  7%   188.4µ ±  8%        ~ (p=0.123 n=10)
	StaticCaseShortestPath/CH_shortest_path/vertices-187853-edges-366113-4                                   1.028m ± 10%   1.108m ± 11%        ~ (p=0.165 n=10)
	PrepareContracts-4                                                                                        2.683 ±  6%    2.710 ±  4%        ~ (p=0.971 n=10)
	geomean                                                                                                  319.3µ         308.5µ         -3.36%