### PR TITLE
Use heap.Init() after pushing vertexes + heap.Fix() for updating priority queue

### DIFF
--- a/contraction.go
+++ b/contraction.go
@@ -18,12 +18,14 @@ func (graph *Graph) Preprocess(pqImportance *importanceHeap) {
 		// update Importance of vertex "on demand" as follows:
 		// Before contracting vertex with currently smallest Importance, recompute its Importance and see if it is still the smallest
 		// If not pick next smallest one, recompute its Importance and see if that is the smallest now; If not, continue in same way ...
-		vertex := heap.Pop(pqImportance).(*Vertex)
+		vertex := pqImportance.Peek()
+		oldimportance := vertex.importance
 		vertex.computeImportance()
-		if pqImportance.Len() != 0 && vertex.importance > pqImportance.Peek().importance {
-			pqImportance.Push(vertex)
+		if vertex.importance != oldimportance {
+			heap.Fix(pqImportance, 0)
 			continue
 		}
+		vertex = heap.Pop(pqImportance).(*Vertex)
 		vertex.orderPos = extractionOrder
 		graph.contractNode(vertex)
 		if graph.verbose {

--- a/graph.go
+++ b/graph.go
@@ -165,14 +165,14 @@ func (graph *Graph) SetVerbose(flag bool) {
 
 // computeImportance Returns heap to store computed importance of each vertex
 func (graph *Graph) computeImportance() *importanceHeap {
-	pqImportance := &importanceHeap{}
-	heap.Init(pqImportance)
+	pqImportance := make(importanceHeap, 0, len(graph.Vertices))
 	for i := range graph.Vertices {
 		graph.Vertices[i].computeImportance()
-		heap.Push(pqImportance, &graph.Vertices[i])
+		pqImportance.Push(&graph.Vertices[i])
 	}
+	heap.Init(&pqImportance)
 	graph.Freeze()
-	return pqImportance
+	return &pqImportance
 }
 
 // Freeze Freeze graph. Should be called after contraction hierarchies had been prepared.


### PR DESCRIPTION
The heap.Init() should be faster than pushing elements individually, but change is not noticeable.

Usual graph changes:

	$ go test ./...
	2024/10/15 17:40:50 TestExport is Ok!
	--- FAIL: TestExport (3.28s)
	    export_test.go:14: Please wait until contraction hierarchy is prepared
	    export_test.go:16: TestExport is starting...
	    export_test.go:21: Number of contractions should be 394840, but got 393658
	--- FAIL: TestImportedFileShortestPath (0.55s)
	    import_test.go:13: TestImportedFileShortestPath is starting...
	    import_test.go:21: Number of contractions should be 394840, but got 393658
	    import_test.go:36: TestImportedFileShortestPath is Ok!
	FAIL
	FAIL    github.com/LdDl/ch      16.187s
	FAIL

Shortest path mixed:

	$ benchstat old-bench.txt new-bench-heap-init-and-fix.txt
	goos: linux
	goarch: amd64
	pkg: github.com/LdDl/ch
	cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
	                                                                                                      │ old-bench.txt │    new-bench-heap-init-and-fix.txt    │
	                                                                                                      │    sec/op     │    sec/op      vs base                │
	ShortestPathManyToMany/CH_shortest_path/4/vertices-4-edges-9-4                                           5.323µ ± 15%    5.012µ ±  9%        ~ (p=0.529 n=10)
	ShortestPathManyToMany/CH_shortest_path/8/vertices-8-edges-61-4                                          9.454µ ±  4%    9.935µ ± 15%        ~ (p=0.165 n=10)
	ShortestPathManyToMany/CH_shortest_path/16/vertices-16-edges-316-4                                       46.65µ ±  9%    52.28µ ± 81%        ~ (p=0.063 n=10)
	ShortestPathManyToMany/CH_shortest_path/32/vertices-32-edges-1404-4                                      179.1µ ±  7%    192.9µ ± 21%   +7.71% (p=0.004 n=10)
	ShortestPathManyToMany/CH_shortest_path/64/vertices-64-edges-5894-4                                      697.2µ ±  9%    735.0µ ± 10%   +5.43% (p=0.019 n=10)
	ShortestPathManyToMany/CH_shortest_path/128/vertices-128-edges-23977-4                                   3.176m ±  8%    3.280m ± 26%        ~ (p=0.075 n=10)
	ShortestPathManyToMany/CH_shortest_path/256/vertices-256-edges-97227-4                                   14.25m ± 11%    15.46m ±  3%   +8.54% (p=0.043 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/4/vertices-4-edges-9-4                                     3.600µ ±  6%    3.511µ ± 50%        ~ (p=0.436 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/8/vertices-8-edges-61-4                                    6.816µ ± 15%    7.707µ ± 15%        ~ (p=0.165 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/16/vertices-16-edges-316-4                                 21.39µ ±  4%    25.44µ ± 15%  +18.91% (p=0.002 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/32/vertices-32-edges-1404-4                                54.42µ ± 11%    59.23µ ± 29%        ~ (p=0.052 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/64/vertices-64-edges-5894-4                                145.2µ ±  7%    156.9µ ± 24%        ~ (p=0.063 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/128/vertices-128-edges-23977-4                             432.9µ ±  9%    418.0µ ± 11%        ~ (p=0.971 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/256/vertices-256-edges-97227-4                             906.8µ ±  7%   1000.5µ ± 11%  +10.33% (p=0.001 n=10)
	StaticCaseShortestPathManyToMany/CH_shortest_path_(many_to_many)/vertices-187853-4                       4.982m ±  8%    5.291m ±  6%        ~ (p=0.105 n=10)
	StaticCaseOldWayShortestPathManyToMany/CH_shortest_path_(many_to_many)/vertices-187853-4                 7.278m ± 15%    7.515m ± 14%        ~ (p=0.529 n=10)
	ShortestPathOneToMany/CH_shortest_path/4/vertices-4-edges-9-4                                            3.201µ ± 24%    3.468µ ± 18%        ~ (p=0.315 n=10)
	ShortestPathOneToMany/CH_shortest_path/8/vertices-8-edges-61-4                                           6.847µ ± 12%    7.653µ ± 21%        ~ (p=0.109 n=10)
	ShortestPathOneToMany/CH_shortest_path/16/vertices-16-edges-316-4                                        21.44µ ± 32%    22.53µ ± 13%        ~ (p=0.987 n=10)
	ShortestPathOneToMany/CH_shortest_path/32/vertices-32-edges-1404-4                                       60.92µ ± 72%    57.64µ ± 13%        ~ (p=0.247 n=10)
	ShortestPathOneToMany/CH_shortest_path/64/vertices-64-edges-5894-4                                       403.0µ ± 46%    131.9µ ± 24%  -67.28% (p=0.000 n=10)
	ShortestPathOneToMany/CH_shortest_path/128/vertices-128-edges-23977-4                                    432.1µ ± 45%    371.5µ ± 10%  -14.02% (p=0.002 n=10)
	ShortestPathOneToMany/CH_shortest_path/256/vertices-256-edges-97227-4                                   1059.7µ ± 11%    916.9µ ±  9%  -13.48% (p=0.001 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/4/vertices-4-edges-9-4                                      3.728µ ± 26%    3.851µ ±  8%        ~ (p=1.000 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/8/vertices-8-edges-61-4                                     6.928µ ± 18%    6.982µ ± 10%        ~ (p=0.529 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/16/vertices-16-edges-316-4                                  21.95µ ±  9%    22.31µ ± 19%        ~ (p=0.912 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/32/vertices-32-edges-1404-4                                 58.13µ ±  8%    56.54µ ±  7%        ~ (p=0.481 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/64/vertices-64-edges-5894-4                                 145.6µ ± 10%    146.9µ ± 11%        ~ (p=0.739 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/128/vertices-128-edges-23977-4                              416.7µ ±  6%    424.2µ ±  6%        ~ (p=0.315 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/256/vertices-256-edges-97227-4                              929.7µ ± 12%    958.0µ ±  7%        ~ (p=0.631 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/2/vertices-187853-edges-366113-targets-1-4             1.754m ±  7%    1.889m ±  8%   +7.71% (p=0.035 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/4/vertices-187853-edges-366113-targets-4-4             2.907m ± 19%    3.103m ± 18%        ~ (p=0.579 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/8/vertices-187853-edges-366113-targets-2-4             1.700m ±  9%    1.608m ±  9%        ~ (p=0.579 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/16/vertices-187853-edges-366113-targets-11-4           5.797m ±  7%    5.970m ± 20%        ~ (p=0.280 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/32/vertices-187853-edges-366113-targets-1-4            1.313m ± 19%    1.365m ± 24%        ~ (p=0.853 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/64/vertices-187853-edges-366113-targets-34-4           18.55m ± 15%    19.18m ±  4%        ~ (p=0.393 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/128/vertices-187853-edges-366113-targets-63-4          33.44m ±  9%    35.47m ± 13%        ~ (p=0.218 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/2/vertices-187853-edges-366113-targets-1-4       1.504m ± 16%    1.500m ± 15%        ~ (p=0.971 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/4/vertices-187853-edges-366113-targets-4-4       5.167m ±  9%    5.183m ±  7%        ~ (p=0.631 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/8/vertices-187853-edges-366113-targets-2-4       2.178m ± 12%    2.166m ±  8%        ~ (p=0.436 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/16/vertices-187853-edges-366113-targets-11-4     13.15m ± 13%    13.24m ± 11%        ~ (p=0.971 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/32/vertices-187853-edges-366113-targets-1-4      1.114m ±  7%    1.017m ± 10%   -8.66% (p=0.015 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/64/vertices-187853-edges-366113-targets-34-4     42.94m ± 19%    41.98m ± 17%        ~ (p=0.739 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/128/vertices-187853-edges-366113-targets-63-4    80.65m ± 13%    82.10m ± 10%        ~ (p=0.971 n=10)
	StaticCaseShortestPathOneToMany/CH_shortest_path_(one_to_many)/vertices-187853-edges-366113-4            3.436m ± 22%    3.733m ± 27%   +8.63% (p=0.035 n=10)
	StaticCaseOldWayShortestPathOneToMany/CH_shortest_path_(one_to_many)/vertices-187853-edges-366113-4      6.823m ±  9%    6.899m ± 20%        ~ (p=0.853 n=10)
	ShortestPath/CH_shortest_path/4/vertices-4-edges-9-4                                                     767.9n ± 21%    770.8n ± 10%        ~ (p=0.579 n=10)
	ShortestPath/CH_shortest_path/8/vertices-8-edges-61-4                                                    1.513µ ±  9%    1.443µ ± 21%        ~ (p=0.579 n=10)
	ShortestPath/CH_shortest_path/16/vertices-16-edges-316-4                                                 4.716µ ± 12%    4.754µ ±  8%        ~ (p=0.853 n=10)
	ShortestPath/CH_shortest_path/32/vertices-32-edges-1404-4                                                11.93µ ±  9%    11.65µ ± 15%        ~ (p=0.971 n=10)
	ShortestPath/CH_shortest_path/64/vertices-64-edges-5894-4                                                28.78µ ± 29%    31.14µ ±  7%        ~ (p=0.247 n=10)
	ShortestPath/CH_shortest_path/128/vertices-128-edges-23977-4                                             83.08µ ±  8%    83.20µ ± 11%        ~ (p=0.971 n=10)
	ShortestPath/CH_shortest_path/256/vertices-256-edges-97227-4                                             195.6µ ±  7%    187.2µ ±  5%        ~ (p=0.123 n=10)
	StaticCaseShortestPath/CH_shortest_path/vertices-187853-edges-366113-4                                   1.028m ± 10%    1.106m ± 12%        ~ (p=0.052 n=10)
	PrepareContracts-4                                                                                        2.683 ±  6%     2.718 ±  5%        ~ (p=0.579 n=10)
	geomean                                                                                                  319.3µ          319.8µ         +0.18%