### PR TITLE
Use edge difference + deleted neighbours for priority

### DIFF
--- a/vertex.go
+++ b/vertex.go
@@ -55,24 +55,7 @@ func (vertex *Vertex) computeImportance() {
 	edgeDiff := shortcutCover - incidentEdgesNum
 	// [+] Spatial diversity heuristic: for each vertex maintain a count of the number of neighbors that have already been contracted [vertex.delNeighbors], and add this to the summary importance
 	// note: the more neighbours have already been contracted, the later this vertex will be contracted in further.
-	// [+] Bidirection edges heuristic: for each vertex check how many bidirected incident edges vertex has.
-	// note: the more bidirected incident edges == less important vertex is.
-	vertex.importance = edgeDiff + incidentEdgesNum + vertex.delNeighbors - vertex.bidirectedEdges()
-}
-
-// bidirectedEdges Number of bidirected edges
-func (vertex *Vertex) bidirectedEdges() int {
-	hash := make(map[int64]struct{}, len(vertex.inIncidentEdges))
-	for _, e := range vertex.inIncidentEdges {
-		hash[e.vertexID] = struct{}{}
-	}
-	ans := 0
-	for i := range vertex.outIncidentEdges {
-		if _, ok := hash[vertex.outIncidentEdges[i].vertexID]; ok {
-			ans++
-		}
-	}
-	return ans
+	vertex.importance = edgeDiff + vertex.delNeighbors
 }
 
 // Distance Information about contraction between source vertex and contraction vertex


### PR DESCRIPTION
Test with simpler (edgediff + deleted neighbours) priority.

It is unclear if current priority code is intended or not:

	shortcutCover := len(vertex.inIncidentEdges) * len(vertex.outIncidentEdges)
	incidentEdgesNum := len(vertex.inIncidentEdges) + len(vertex.outIncidentEdges)
	edgeDiff := shortcutCover - incidentEdgesNum
	vertex.importance = edgeDiff + incidentEdgesNum + vertex.delNeighbors - vertex.bidirectedEdges()

If we replace edgeDiff then we get:

	vertex.importance = shortcutCover - incidentEdgesNum + incidentEdgesNum + vertex.delNeighbors - vertex.bidirectedEdges()

which will simplify to:

	vertex.importance = shortcutCover + vertex.delNeighbors - vertex.bidirectedEdges()

For most ways are two-ways then `vertex.bidirectedEdges()` would be equal to `incidentEdgesNum/2` so we end up something close to this:

	vertex.importance = shortcutCover + vertex.delNeighbors - incidentEdgesNum/2

which is basically ~edge difference (with 1/2 removed edges) + contracted neighbors.

I don't see good reason for `vertex.bidirectedEdges()` complexity, would just go with:

	edge difference + contracted neighbors

ref: https://jlazarsfeld.github.io/ch.150.project/sections/12-node-order/#other-cost-functions

---
Mixed results.

	$ go test ./...
	2024/10/15 20:54:49 TestExport is Ok!
	--- FAIL: TestExport (3.28s)
	    export_test.go:14: Please wait until contraction hierarchy is prepared
	    export_test.go:16: TestExport is starting...
	    export_test.go:21: Number of contractions should be 394840, but got 397495
	--- FAIL: TestImportedFileShortestPath (0.64s)
	    import_test.go:13: TestImportedFileShortestPath is starting...
	    import_test.go:21: Number of contractions should be 394840, but got 397495
	    import_test.go:36: TestImportedFileShortestPath is Ok!
	FAIL
	FAIL    github.com/LdDl/ch      16.242s
	FAIL


	$ go test -run=^$ -bench ^Benchmark ./... -v -count=10 -timeout 20m > new-bench-priority-change.txt

	$ benchstat old-bench.txt new-bench-priority-change.txt

	goos: linux
	goarch: amd64
	pkg: github.com/LdDl/ch
	cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
	                                                                                                      │ old-bench.txt │     new-bench-priority-change.txt     │
	                                                                                                      │    sec/op     │    sec/op      vs base                │
	ShortestPathManyToMany/CH_shortest_path/4/vertices-4-edges-9-4                                           5.323µ ± 15%    5.084µ ±  9%        ~ (p=0.796 n=10)
	ShortestPathManyToMany/CH_shortest_path/8/vertices-8-edges-61-4                                          9.454µ ±  4%    9.363µ ± 14%        ~ (p=1.000 n=10)
	ShortestPathManyToMany/CH_shortest_path/16/vertices-16-edges-316-4                                       46.65µ ±  9%    49.67µ ±  6%   +6.47% (p=0.043 n=10)
	ShortestPathManyToMany/CH_shortest_path/32/vertices-32-edges-1404-4                                      179.1µ ±  7%    181.6µ ± 15%        ~ (p=0.393 n=10)
	ShortestPathManyToMany/CH_shortest_path/64/vertices-64-edges-5894-4                                      697.2µ ±  9%    723.4µ ±  7%        ~ (p=0.089 n=10)
	ShortestPathManyToMany/CH_shortest_path/128/vertices-128-edges-23977-4                                   3.176m ±  8%    3.234m ±  7%        ~ (p=0.315 n=10)
	ShortestPathManyToMany/CH_shortest_path/256/vertices-256-edges-97227-4                                   14.25m ± 11%    14.85m ± 14%        ~ (p=0.247 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/4/vertices-4-edges-9-4                                     3.600µ ±  6%    3.538µ ± 13%        ~ (p=0.739 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/8/vertices-8-edges-61-4                                    6.816µ ± 15%    7.007µ ± 10%        ~ (p=0.529 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/16/vertices-16-edges-316-4                                 21.39µ ±  4%    22.31µ ±  6%   +4.27% (p=0.023 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/32/vertices-32-edges-1404-4                                54.42µ ± 11%    54.71µ ±  3%        ~ (p=0.529 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/64/vertices-64-edges-5894-4                                145.2µ ±  7%    144.8µ ± 12%        ~ (p=0.853 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/128/vertices-128-edges-23977-4                             432.9µ ±  9%    415.9µ ± 10%        ~ (p=0.739 n=10)
	OldWayShortestPathManyToMany/CH_shortest_path/256/vertices-256-edges-97227-4                             906.8µ ±  7%    989.5µ ± 13%   +9.11% (p=0.015 n=10)
	StaticCaseShortestPathManyToMany/CH_shortest_path_(many_to_many)/vertices-187853-4                       4.982m ±  8%    5.800m ± 11%  +16.41% (p=0.004 n=10)
	StaticCaseOldWayShortestPathManyToMany/CH_shortest_path_(many_to_many)/vertices-187853-4                 7.278m ± 15%    7.152m ± 15%        ~ (p=0.796 n=10)
	ShortestPathOneToMany/CH_shortest_path/4/vertices-4-edges-9-4                                            3.201µ ± 24%    3.453µ ± 20%        ~ (p=0.436 n=10)
	ShortestPathOneToMany/CH_shortest_path/8/vertices-8-edges-61-4                                           6.847µ ± 12%    6.387µ ± 20%        ~ (p=0.123 n=10)
	ShortestPathOneToMany/CH_shortest_path/16/vertices-16-edges-316-4                                        21.44µ ± 32%    21.65µ ± 11%        ~ (p=0.912 n=10)
	ShortestPathOneToMany/CH_shortest_path/32/vertices-32-edges-1404-4                                       60.92µ ± 72%    51.12µ ± 21%  -16.09% (p=0.035 n=10)
	ShortestPathOneToMany/CH_shortest_path/64/vertices-64-edges-5894-4                                       403.0µ ± 46%    129.1µ ± 21%  -67.96% (p=0.000 n=10)
	ShortestPathOneToMany/CH_shortest_path/128/vertices-128-edges-23977-4                                    432.1µ ± 45%    377.9µ ±  9%  -12.54% (p=0.002 n=10)
	ShortestPathOneToMany/CH_shortest_path/256/vertices-256-edges-97227-4                                   1059.7µ ± 11%    984.3µ ±  8%   -7.11% (p=0.043 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/4/vertices-4-edges-9-4                                      3.728µ ± 26%    3.566µ ± 15%        ~ (p=0.247 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/8/vertices-8-edges-61-4                                     6.928µ ± 18%    6.997µ ± 30%        ~ (p=0.542 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/16/vertices-16-edges-316-4                                  21.95µ ±  9%    22.97µ ± 13%        ~ (p=0.280 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/32/vertices-32-edges-1404-4                                 58.13µ ±  8%    57.84µ ± 15%        ~ (p=0.971 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/64/vertices-64-edges-5894-4                                 145.6µ ± 10%    147.5µ ± 12%        ~ (p=0.436 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/128/vertices-128-edges-23977-4                              416.7µ ±  6%    418.3µ ±  9%        ~ (p=0.436 n=10)
	OldWayShortestPathOneToMany/CH_shortest_path/256/vertices-256-edges-97227-4                              929.7µ ± 12%   1009.3µ ± 23%   +8.56% (p=0.019 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/2/vertices-187853-edges-366113-targets-1-4             1.754m ±  7%    2.318m ± 32%  +32.17% (p=0.000 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/4/vertices-187853-edges-366113-targets-4-4             2.907m ± 19%    3.858m ± 31%  +32.74% (p=0.000 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/8/vertices-187853-edges-366113-targets-2-4             1.700m ±  9%    1.813m ± 31%        ~ (p=0.052 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/16/vertices-187853-edges-366113-targets-11-4           5.797m ±  7%    6.691m ± 20%  +15.42% (p=0.004 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/32/vertices-187853-edges-366113-targets-1-4            1.313m ± 19%    1.300m ± 13%        ~ (p=1.000 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/64/vertices-187853-edges-366113-targets-34-4           18.55m ± 15%    20.65m ±  9%        ~ (p=0.052 n=10)
	TargetNodesShortestPathOneToMany/CH_shortest_path/128/vertices-187853-edges-366113-targets-63-4          33.44m ±  9%    37.67m ± 10%  +12.66% (p=0.009 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/2/vertices-187853-edges-366113-targets-1-4       1.504m ± 16%    1.460m ± 22%        ~ (p=0.631 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/4/vertices-187853-edges-366113-targets-4-4       5.167m ±  9%    5.841m ± 16%        ~ (p=0.052 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/8/vertices-187853-edges-366113-targets-2-4       2.178m ± 12%    2.207m ± 21%        ~ (p=0.853 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/16/vertices-187853-edges-366113-targets-11-4     13.15m ± 13%    13.88m ± 14%        ~ (p=0.315 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/32/vertices-187853-edges-366113-targets-1-4      1.114m ±  7%    1.089m ± 10%        ~ (p=0.481 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/64/vertices-187853-edges-366113-targets-34-4     42.94m ± 19%    45.43m ± 10%        ~ (p=0.353 n=10)
	TargetNodesOldWayShortestPathOneToMany/CH_shortest_path/128/vertices-187853-edges-366113-targets-63-4    80.65m ± 13%    80.67m ±  8%        ~ (p=0.684 n=10)
	StaticCaseShortestPathOneToMany/CH_shortest_path_(one_to_many)/vertices-187853-edges-366113-4            3.436m ± 22%    4.426m ± 50%  +28.80% (p=0.004 n=10)
	StaticCaseOldWayShortestPathOneToMany/CH_shortest_path_(one_to_many)/vertices-187853-edges-366113-4      6.823m ±  9%    7.798m ± 37%  +14.29% (p=0.002 n=10)
	ShortestPath/CH_shortest_path/4/vertices-4-edges-9-4                                                     767.9n ± 21%    827.9n ± 18%        ~ (p=0.353 n=10)
	ShortestPath/CH_shortest_path/8/vertices-8-edges-61-4                                                    1.513µ ±  9%    1.435µ ± 21%        ~ (p=0.971 n=10)
	ShortestPath/CH_shortest_path/16/vertices-16-edges-316-4                                                 4.716µ ± 12%    5.199µ ± 16%        ~ (p=0.436 n=10)
	ShortestPath/CH_shortest_path/32/vertices-32-edges-1404-4                                                11.93µ ±  9%    12.25µ ± 14%        ~ (p=0.529 n=10)
	ShortestPath/CH_shortest_path/64/vertices-64-edges-5894-4                                                28.78µ ± 29%    32.09µ ±  8%        ~ (p=0.143 n=10)
	ShortestPath/CH_shortest_path/128/vertices-128-edges-23977-4                                             83.08µ ±  8%    85.32µ ± 11%        ~ (p=0.165 n=10)
	ShortestPath/CH_shortest_path/256/vertices-256-edges-97227-4                                             195.6µ ±  7%    200.9µ ± 16%        ~ (p=0.481 n=10)
	StaticCaseShortestPath/CH_shortest_path/vertices-187853-edges-366113-4                                   1.028m ± 10%    1.147m ± 16%  +11.55% (p=0.019 n=10)
	PrepareContracts-4                                                                                        2.683 ±  6%     2.673 ±  8%        ~ (p=0.739 n=10)
	geomean                                                                                                  319.3µ          324.7µ         +1.71%


----
