### PR TITLE
perf: do not process nodes multiple times

### DIFF
--- a/bidirectional_ch_test.go
+++ b/bidirectional_ch_test.go
@@ -152,7 +152,7 @@ func TestBadSpatialShortestPath(t *testing.T) {
 	t.Log("TestBadSpatialShortestPath is Ok!")
 }
 
-func TestLittleShortestPath(t *testing.T) {
+func makeLittleGraph() Graph {
 	g := Graph{}
 	g.CreateVertex(0)
 	g.CreateVertex(1)
@@ -184,6 +184,11 @@ func TestLittleShortestPath(t *testing.T) {
 	g.AddEdge(5, 6, 4.0)
 
 	g.PrepareContractionHierarchies()
+	return g
+}
+
+func TestLittleShortestPath(t *testing.T) {
+	g := makeLittleGraph()
 	t.Log("TestLittleShortestPath is starting...")
 	u := int64(0)
 	v := int64(7)
@@ -196,6 +201,38 @@ func TestLittleShortestPath(t *testing.T) {
 		t.Errorf("Length of path should be 20.0, but got %f", ans)
 	}
 	t.Log("TestLittleShortestPath is Ok!")
+}
+
+func TestLittleSameNodeShortestPath(t *testing.T) {
+	g := makeLittleGraph()
+	t.Log("TestLittleSameNodeShortestPath is starting...")
+	u := int64(0)
+	v := int64(0)
+	//
+	ans, path := g.ShortestPath(u, v)
+	if len(path) != 1 {
+		t.Errorf("Num of vertices in path should be 1, but got %d", len(path))
+	}
+	if Round(ans, 0.00005) != Round(0.0, 0.00005) {
+		t.Errorf("Length of path should be 0.0, but got %f", ans)
+	}
+	t.Log("TestLittleSameNodeShortestPath is Ok!")
+}
+
+func TestLittleOneStepShortestPath(t *testing.T) {
+	g := makeLittleGraph()
+	t.Log("TestLittleOneStepShortestPath is starting...")
+	u := int64(0)
+	v := int64(1)
+	//
+	ans, path := g.ShortestPath(u, v)
+	if len(path) != 2 {
+		t.Errorf("Num of vertices in path should be 2, but got %d", len(path))
+	}
+	if Round(ans, 0.00005) != Round(6.0, 0.00005) {
+		t.Errorf("Length of path should be 6.0, but got %f", ans)
+	}
+	t.Log("TestLittleOneStepShortestPath is Ok!")
 }
 
 func TestVertexAlternatives(t *testing.T) {

--- a/dijkstra_bidirectional.go
+++ b/dijkstra_bidirectional.go
@@ -46,7 +46,6 @@ func (graph *Graph) initShortestPath() (queryDist [directionsCount]map[int64]flo
 func (graph *Graph) shortestPath(endpoints [directionsCount]int64) (float64, []int64) {
 	queryDist, processed, queues := graph.initShortestPath()
 	for d := forward; d < directionsCount; d++ {
-		processed[d][endpoints[d]] = true
 		queryDist[d][endpoints[d]] = 0
 		heapEndpoint := &vertexDist{
 			id:   endpoints[d],
@@ -86,42 +85,46 @@ func (graph *Graph) shortestPathCore(queryDist [directionsCount]map[int64]float6
 
 func (graph *Graph) directionalSearch(d direction, q *vertexDistHeap, localProcessed, reverseProcessed map[int64]bool, localQueryDist, reverseQueryDist map[int64]float64, prev map[int64]int64, estimate *float64, middleID *int64) {
 	vertex := heap.Pop(q).(*vertexDist)
+	if vertex.dist >= *estimate {
+		return
+	}
+	if localProcessed[vertex.id] {
+		return
+	}
 	if graph.Reporter != nil {
 		graph.Reporter.VertexSettled(int(d), 0, vertex.id, q.Len())
 	}
-	if vertex.dist <= *estimate {
-		localProcessed[vertex.id] = true
-		// Edge relaxation in a forward propagation
-		var vertexList []incidentEdge
-		if d == forward {
-			vertexList = graph.Vertices[vertex.id].outIncidentEdges
-		} else {
-			vertexList = graph.Vertices[vertex.id].inIncidentEdges
-		}
+	localProcessed[vertex.id] = true
+	// Edge relaxation in a forward propagation
+	var vertexList []incidentEdge
+	if d == forward {
+		vertexList = graph.Vertices[vertex.id].outIncidentEdges
+	} else {
+		vertexList = graph.Vertices[vertex.id].inIncidentEdges
+	}
 
-		for i := range vertexList {
-			temp := vertexList[i].vertexID
-			cost := vertexList[i].weight
-			alt := vertex.dist + cost
-			if graph.Vertices[vertex.id].orderPos < graph.Vertices[temp].orderPos {
-				localDist, ok := localQueryDist[temp]
-				if !ok {
-					localDist = Infinity
-				}
-				if localDist > alt {
+	for i := range vertexList {
+		temp := vertexList[i].vertexID
+		cost := vertexList[i].weight
+		alt := vertex.dist + cost
+		if graph.Vertices[vertex.id].orderPos < graph.Vertices[temp].orderPos {
+			localDist, ok := localQueryDist[temp]
+			if !ok {
+				localDist = Infinity
+			}
+			if localDist > alt {
+				if graph.Reporter != nil {
 					if graph.Reporter != nil {
-						if graph.Reporter != nil {
-							graph.Reporter.EdgeRelaxed(int(d), 0, vertex.id, temp, true, q.Len())
-						}
+						graph.Reporter.EdgeRelaxed(int(d), 0, vertex.id, temp, true, q.Len())
 					}
-					localQueryDist[temp] = alt
-					prev[temp] = vertex.id
-					node := &vertexDist{
-						id:   temp,
-						dist: alt,
-					}
-					heap.Push(q, node)
 				}
+				localQueryDist[temp] = alt
+				prev[temp] = vertex.id
+				node := &vertexDist{
+					id:   temp,
+					dist: alt,
+				}
+				heap.Push(q, node)
 			}
 		}
 	}
@@ -164,7 +167,6 @@ func (graph *Graph) shortestPathWithAlternatives(endpoints [directionsCount][]ve
 			if endpoint.vertexNum == vertexNotFound {
 				continue
 			}
-			processed[d][endpoint.vertexNum] = true
 			queryDist[d][endpoint.vertexNum] = endpoint.additionalDistance
 			heapEndpoint := &vertexDist{
 				id:   endpoint.vertexNum,

--- a/dijkstra_bidirectional.go
+++ b/dijkstra_bidirectional.go
@@ -99,15 +99,10 @@ func (graph *Graph) directionalSearch(d direction, q *vertexDistHeap, localProce
 			vertexList = graph.Vertices[vertex.id].inIncidentEdges
 		}
 
-		distance, ok := localQueryDist[vertex.id]
-		if !ok {
-			distance = Infinity
-		}
-
 		for i := range vertexList {
 			temp := vertexList[i].vertexID
 			cost := vertexList[i].weight
-			alt := distance + cost
+			alt := vertex.dist + cost
 			if graph.Vertices[vertex.id].orderPos < graph.Vertices[temp].orderPos {
 				localDist, ok := localQueryDist[temp]
 				if !ok {


### PR DESCRIPTION
Also, use `vertex.dist` instead of looking up in map.

The effect is smaller than I anticipated, but still around 5%.

```
$ benchstat /tmp/ch-bench/master-10-1.txt /tmp/ch-bench/processed-check-10-1.txt
goos: linux
goarch: amd64
pkg: github.com/LdDl/ch
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
                                                             │ /tmp/ch-bench/master-10-1.txt │ /tmp/ch-bench/processed-check-10-1.txt │
                                                             │            sec/op             │     sec/op       vs base               │
ShortestPath/CH_shortest_path/4/vertices-4-edges-9-6                             1.356µ ± 3%       1.334µ ± 2%       ~ (p=0.305 n=10)
ShortestPath/CH_shortest_path/8/vertices-8-edges-61-6                            2.576µ ± 9%       2.483µ ± 1%  -3.65% (p=0.000 n=10)
ShortestPath/CH_shortest_path/16/vertices-16-edges-316-6                         8.795µ ± 3%       8.208µ ± 4%  -6.67% (p=0.000 n=10)
ShortestPath/CH_shortest_path/32/vertices-32-edges-1404-6                        21.24µ ± 6%       19.91µ ± 1%  -6.27% (p=0.000 n=10)
ShortestPath/CH_shortest_path/64/vertices-64-edges-5894-6                        51.32µ ± 2%       49.15µ ± 2%  -4.24% (p=0.002 n=10)
ShortestPath/CH_shortest_path/128/vertices-128-edges-23977-6                     140.0µ ± 2%       135.0µ ± 3%  -3.55% (p=0.000 n=10)
ShortestPath/CH_shortest_path/256/vertices-256-edges-97227-6                     354.9µ ± 4%       333.1µ ± 2%  -6.15% (p=0.000 n=10)
geomean                                                                          20.76µ            19.81µ       -4.61%
```