### PR TITLE
chore: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v9
+    - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
       with:
         days-before-stale: 7
         stale-issue-message: 'This issue has been stale for 7 days, and it will be closed in 7 days unless action is taken.'


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to full-length commit SHAs for security hardening
- Enables the "Require actions to be pinned to a full-length commit SHA" repository safeguard
- Original version tags preserved as inline comments for readability

## Test plan
- [ ] Verify CI pipeline runs successfully with pinned actions
- [ ] Confirm all workflows still trigger and execute correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)